### PR TITLE
fix: Simulate a device that supports video

### DIFF
--- a/src/factory/RequestBuilder.ts
+++ b/src/factory/RequestBuilder.ts
@@ -88,6 +88,7 @@ export abstract class RequestBuilder {
     }
     if (this.settings.interfaces!.video) {
       ctx.System.device!.supportedInterfaces.VideoApp = {};
+      ctx.Viewport = { video: { codecs: [ 'H_264_41', 'H_264_42' ] } }
     }
     if (this.settings.interfaces!.apl) {
       ctx.System.device!.supportedInterfaces['Alexa.Presentation.APL'] = { runtime: { maxVersion: '1.3' } };

--- a/src/factory/RequestBuilder.ts
+++ b/src/factory/RequestBuilder.ts
@@ -88,7 +88,7 @@ export abstract class RequestBuilder {
     }
     if (this.settings.interfaces!.video) {
       ctx.System.device!.supportedInterfaces.VideoApp = {};
-      ctx.Viewport = { video: { codecs: [ 'H_264_41', 'H_264_42' ] } }
+      ctx.Viewport = { video: { codecs: ['H_264_41', 'H_264_42'] } };
     }
     if (this.settings.interfaces!.apl) {
       ctx.System.device!.supportedInterfaces['Alexa.Presentation.APL'] = { runtime: { maxVersion: '1.3' } };


### PR DESCRIPTION
Using the condition `.withInterfaces({ video: true }).build()` to build a request does not make the `handlerInput.requestEnvelope.context.Viewport.video` to be _truthy_ in order to simulate a device that does support video. It only changes the value of `handlerInput.requestEnvelope.context.System.device.supportedInterfaces.VideoApp`.

The `Viewport.video` property represents an object including an array of `codecs` that contains the available technologies for playing video on the device. If it does not support playing videos, the `Viewport.video` property is not present. To simulate a device that does support playing video it should be enough to make that property exist (or be _truthy_). In this PR, this property has been set to contain an array with all the possible `codecs` that the output device could support.

Here's the related issue:
- https://github.com/taimos/ask-sdk-test/issues/31